### PR TITLE
Move \fancyhf out of \ifdocumenttype

### DIFF
--- a/templates/livecoms.cls
+++ b/templates/livecoms.cls
@@ -218,8 +218,8 @@
 % nothing
 \fi
 
-\ifdocumenttype
 \fancyhf{}
+\ifdocumenttype
 \chead{%
 \setlength{\fboxsep}{3pt}
 \colorbox{LiveCoMSMediumGrey}{\begin{minipage}{\headwidth}\centering\color{white} A LiveCoMS \documenttype\end{minipage}}%


### PR DESCRIPTION
Fixes inconsistent header when no document type is specified, as described in https://github.com/livecomsjournal/article_templates/issues/33