### PR TITLE
Fixes for bibliography style - month, URL vs. DOI, and techpreport URLs

### DIFF
--- a/bibliography_guidelines.md
+++ b/bibliography_guidelines.md
@@ -21,9 +21,10 @@ A sample bibliography file is provided in the LiveCoMS Article Template reposito
   * DOI
   * Publisher URL
   * some other ID
-- Entries in the BibTeX file are formatted as follows:
+- The vancouver-livecoms.bst style will prefer to include the DOI, and suppress a separate URL, if the DOI is supplied, so that only one electronic link is included in the citation.
+- Electronic links in the BibTeX file are formatted as follows:
   * DOI: doi = {10.1093/nar/gkr1030}
-  * Publisher URL: URL = {http://nar.oxfordjournals.org/content/40/D1/D706.abstract}
+  * Publisher URL: url = {http://nar.oxfordjournals.org/content/40/D1/D706.abstract}
   * An alternate ID can be provided via the "note" tag, such as: note = {PubMed: https://www.ncbi.nlm.nih.gov/pubmed/20454547}
 - Do not include the "http://" or "https://" prefix in DOI tags
 

--- a/templates/vancouver-livecoms.bst
+++ b/templates/vancouver-livecoms.bst
@@ -879,12 +879,15 @@ FUNCTION {format.inventors}
 
 FUNCTION {format.note}
 {
-  url empty$
-    'skip$
-    { "\urlprefix\url{" url * "}" * output }
-  if$
+  %%url empty$
+  %%  'skip$
+  %%  { "\urlprefix\url{" url * "}" * output }
+  %%if$
   doi empty$
-    'skip$
+    {url empty$
+      'skip$
+      { "\urlprefix\url{" url * "}" * output }
+    if$}
     { "\href{https://dx.doi.org/" doi * "}{\doiprefix \detokenize{" * doi * "}}" * output }
   if$
  note empty$

--- a/templates/vancouver-livecoms.bst
+++ b/templates/vancouver-livecoms.bst
@@ -1012,7 +1012,9 @@ FUNCTION {word.in}
 
 FUNCTION {format.journal.date}
 {
-  month "month" bibinfo.check
+  %month "month" bibinfo.check  %% removed to suppress month
+  no.blank.or.punct  %% added to achieve proper ordering (journal name. Year ; ...)
+  ""
   duplicate$ empty$
   year  "year"  bibinfo.check duplicate$ empty$
     {

--- a/templates/vancouver-livecoms.bst
+++ b/templates/vancouver-livecoms.bst
@@ -1629,8 +1629,8 @@ FUNCTION {techreport}
   format.institution.address output
   format.date "year" output.check
 %  format.tr.number output.nonnull
-%  new.block
-%  format.note output
+  new.block
+  format.note output
 %  output.web.refs  % urlbst
   fin.entry
 }


### PR DESCRIPTION
Three fixes for the BibTeX style:
1. Suppresses month for articles
2. Includes, in order or preference, DOI -or- URL -or- <nothing>, but never DOI and URL simultaneously
3. Includes URL for "techreport" keys (we need this for the Sampling-Uncertainty paper, since two the JCGM technical reports we cite do not have DOIs [though they should]).

This should address all changes to the vancouver-livecoms.bst file discussed in #53. It needs to be followed-up by adjustments to the guidelines for references in the github.io repo.