### PR TITLE
Mod to BST that bolds first editor for Book item type

### DIFF
--- a/templates/vancouver-livecoms.bst
+++ b/templates/vancouver-livecoms.bst
@@ -804,6 +804,7 @@ FUNCTION {format.names.ed}
 {
   format.names
 }
+
 FUNCTION {format.key}
 { empty$
     { key field.or.null }
@@ -834,7 +835,7 @@ FUNCTION {get.bbl.assignee}
 { assignee num.names$ #1 > 'bbl.assignees 'bbl.assignee if$ }
 
 FUNCTION {format.editors}
-{ editor "editor" format.names duplicate$ empty$ 'skip$
+{ editor "editor" format.names.auth duplicate$ empty$ 'skip$
     {
       "," *
       " " *


### PR DESCRIPTION
Finally found a fix so that first/only editor of "Book" item in BIB file is bolded, like the first/only author of an article. The mod does not affect "InBook" or "Misc" items that include the editor field.